### PR TITLE
Improvements

### DIFF
--- a/jailbreakd/kern_utils.m
+++ b/jailbreakd/kern_utils.m
@@ -1,3 +1,4 @@
+#import <Foundation/Foundation.h>
 #import "debug.h"
 #import "kern_utils.h"
 #import "patchfinder64.h"

--- a/jailbreakd/kern_utils.m
+++ b/jailbreakd/kern_utils.m
@@ -48,6 +48,10 @@ unsigned offsetof_csb_signer_type = 0xA0;     // cs_blob::csb_signer_type
 unsigned offsetof_csb_platform_binary = 0xA4; // cs_blob::csb_platform_binary
 unsigned offsetof_csb_platform_path = 0xA8;   // cs_blob::csb_platform_path
 
+unsigned offsetof_t_flags = 0x3a0; // task::t_flags
+
+#define TF_PLATFORM 0x400
+
 #define	CS_VALID		0x0000001	/* dynamically valid */
 #define CS_ADHOC		0x0000002	/* ad hoc signed */
 #define CS_GET_TASK_ALLOW	0x0000004	/* has get-task-allow entitlement */
@@ -310,6 +314,18 @@ int setcsflagsandplatformize(int pd){
               NSLog(@"New CSFlags: 0x%x", csflags);
 #endif
               wk32(proc + offsetof_p_csflags, csflags);
+
+              // task.t_flags & TF_PLATFORM
+              uint64_t task = rk64(proc + offsetof_task);
+              uint32_t t_flags = rk32(task + offsetof_t_flags);
+#if JAILBREAKDDEBUG
+              NSLog(@"Old t_flags: 0x%x", t_flags);
+#endif
+              t_flags |= TF_PLATFORM;
+              wk32(task+offsetof_t_flags, t_flags);
+#if JAILBREAKDDEBUG
+              NSLog(@"New t_flags: 0x%x", t_flags);
+#endif
 
               // AMFI entitlements
 #if JAILBREAKDDEBUG

--- a/jailbreakd/main.m
+++ b/jailbreakd/main.m
@@ -1,3 +1,4 @@
+#import <Foundation/Foundation.h>
 #include <stdio.h>
 #include <mach/mach.h>
 #include <mach/error.h>

--- a/jailbreakd/offsets.m
+++ b/jailbreakd/offsets.m
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/sysctl.h>
 #include <sys/utsname.h>
 


### PR DESCRIPTION
Jailbreakd
---
1) I don't want to install theos just to build one binary, so I'm using this

```sh
xcrun -sdk iphoneos clang \
  -arch arm64 \
  *.m *.c -I. \ 
  -o jailbreakd \
  -framework Foundation -framework IOKit

jtool --sign --inplace --ent Ent.plist jailbreakd
```

However, some files are using library functions without including needed headers. It won't hurt to add them -- it won't break theos build.

2) in iOS 11 platform binaries have `TF_PLATFORM` flag on task. `platform-application` doesn't set it.
However, it's used in task_for_pid checks (you can't get task for platform application unless you are platform application too). Launchd also checks it (so launchctl binary which doesn't have that flag would get error `154: Requestor is not a platform binary`)


amfi payload
---

Handle SHA-1 hashes properly.

iOS still supports SHA-256 and SHA-1, but it always used sha256
so cdhash returned by amfid is different from hash kernel had
kernel notices that and assumes that somebody replaced binary after kernel's and before amfid's check, so it shows that race condition error and aborts execution.

I think we're fine with using sha256 only in fun.c since it will only contain our own binaries.