### PR TITLE
jailbreakd

### DIFF
--- a/basebinaries/jailbreakd/kern_utils.h
+++ b/basebinaries/jailbreakd/kern_utils.h
@@ -69,14 +69,13 @@ kern_return_t mach_vm_write(vm_map_t target_task, mach_vm_address_t address, vm_
 kern_return_t mach_vm_allocate(vm_map_t target, mach_vm_address_t *address, mach_vm_size_t size, int flags);
 kern_return_t mach_vm_deallocate(vm_map_t target, mach_vm_address_t address, mach_vm_size_t size);
 
-uint64_t kalloc(vm_size_t size);
-uint32_t rk32(uint64_t kaddr);
-uint64_t rk64(uint64_t kaddr);
-void wk64(uint64_t kaddr, uint64_t val);
-
 mach_port_t prepare_user_client();
 uint64_t find_port(mach_port_name_t port);
 
 int dumppid(int pd);
 int setcsflagsandplatformize(int pd);
+
+extern mach_port_t tfpzero;
+extern uint64_t kernel_base;
+extern uint64_t kernel_slide;
 

--- a/basebinaries/jailbreakd/kern_utils.h
+++ b/basebinaries/jailbreakd/kern_utils.h
@@ -69,7 +69,6 @@ kern_return_t mach_vm_write(vm_map_t target_task, mach_vm_address_t address, vm_
 kern_return_t mach_vm_allocate(vm_map_t target, mach_vm_address_t *address, mach_vm_size_t size, int flags);
 kern_return_t mach_vm_deallocate(vm_map_t target, mach_vm_address_t address, mach_vm_size_t size);
 
-mach_port_t prepare_user_client();
 uint64_t find_port(mach_port_name_t port);
 
 int dumppid(int pd);

--- a/basebinaries/jailbreakd/kern_utils.m
+++ b/basebinaries/jailbreakd/kern_utils.m
@@ -4,6 +4,7 @@
 #import "patchfinder64.h"
 #import "kexecute.h"
 #import "offsetof.h"
+#import "osobject.h"
 
 #define TF_PLATFORM 0x400
 
@@ -77,18 +78,6 @@ uint64_t find_port(mach_port_name_t port){
   uint64_t port_addr = rk64(is_table + (port_index * sizeof_ipc_entry_t));
   return port_addr;
 }
-
-#define OSDictionary_ItemCount(dict) rk32(dict+20)
-#define OSDictionary_ItemBuffer(dict) rk64(dict+32)
-#define OSDictionary_ItemKey(buffer, idx) rk64(buffer+16*idx)
-#define OSDictionary_ItemValue(buffer, idx) rk64(buffer+16*idx+8)
-                uint32_t SetObjectWithCharP = 8*31;
-#define OSDictionary_SetItem(dict, str, val) {\
-uint64_t s = kalloc(strlen(str)+1); kwrite(s, str, strlen(str)); \
-kexecute(rk64(rk64(dict)+SetObjectWithCharP), dict, s, val, 0, 0, 0, 0); \
-kfree(s, strlen(str)+1); \
-            }
-#define OSString_CStringPtr(str) rk64(str+0x10)
 
 int dumppid(int pd){
   uint64_t proc = proc_find(pd, 3);

--- a/basebinaries/jailbreakd/kern_utils.m
+++ b/basebinaries/jailbreakd/kern_utils.m
@@ -3,48 +3,7 @@
 #import "kmem.h"
 #import "patchfinder64.h"
 #import "kexecute.h"
-
-unsigned offsetof_p_pid = 0x10;               // proc_t::p_pid
-unsigned offsetof_task = 0x18;                // proc_t::task
-unsigned offsetof_p_uid = 0x30;               // proc_t::p_uid
-unsigned offsetof_p_gid = 0x34;               // proc_t::p_uid
-unsigned offsetof_p_ruid = 0x38;              // proc_t::p_uid
-unsigned offsetof_p_rgid = 0x3c;              // proc_t::p_uid
-unsigned offsetof_p_ucred = 0x100;            // proc_t::p_ucred
-unsigned offsetof_p_csflags = 0x2a8;          // proc_t::p_csflags
-unsigned offsetof_itk_self = 0xD8;            // task_t::itk_self (convert_task_to_port)
-unsigned offsetof_itk_sself = 0xE8;           // task_t::itk_sself (task_get_special_port)
-unsigned offsetof_itk_bootstrap = 0x2b8;      // task_t::itk_bootstrap (task_get_special_port)
-unsigned offsetof_itk_space = 0x308;          // task_t::itk_space
-unsigned offsetof_ip_mscount = 0x9C;          // ipc_port_t::ip_mscount (ipc_port_make_send)
-unsigned offsetof_ip_srights = 0xA0;          // ipc_port_t::ip_srights (ipc_port_make_send)
-unsigned offsetof_ip_kobject = 0x68;          // ipc_port_t::ip_kobject
-unsigned offsetof_p_textvp = 0x248;           // proc_t::p_textvp
-unsigned offsetof_p_textoff = 0x250;          // proc_t::p_textoff
-unsigned offsetof_p_cputype = 0x2c0;          // proc_t::p_cputype
-unsigned offsetof_p_cpu_subtype = 0x2c4;      // proc_t::p_cpu_subtype
-unsigned offsetof_special = 2 * sizeof(long); // host::special
-unsigned offsetof_ipc_space_is_table = 0x20;  // ipc_space::is_table?..
-
-unsigned offsetof_ucred_cr_uid = 0x18;        // ucred::cr_uid
-unsigned offsetof_ucred_cr_ruid = 0x1c;       // ucred::cr_ruid
-unsigned offsetof_ucred_cr_svuid = 0x20;      // ucred::cr_svuid
-
-unsigned offsetof_v_type = 0x70;              // vnode::v_type
-unsigned offsetof_v_id = 0x74;                // vnode::v_id
-unsigned offsetof_v_ubcinfo = 0x78;           // vnode::v_ubcinfo
-
-unsigned offsetof_ubcinfo_csblobs = 0x50;     // ubc_info::csblobs
-
-unsigned offsetof_csb_cputype = 0x8;          // cs_blob::csb_cputype
-unsigned offsetof_csb_flags = 0x12;           // cs_blob::csb_flags
-unsigned offsetof_csb_base_offset = 0x16;     // cs_blob::csb_base_offset
-unsigned offsetof_csb_entitlements_offset = 0x98; // cs_blob::csb_entitlements
-unsigned offsetof_csb_signer_type = 0xA0;     // cs_blob::csb_signer_type
-unsigned offsetof_csb_platform_binary = 0xA4; // cs_blob::csb_platform_binary
-unsigned offsetof_csb_platform_path = 0xA8;   // cs_blob::csb_platform_path
-
-unsigned offsetof_t_flags = 0x3a0; // task::t_flags
+#import "offsetof.h"
 
 #define TF_PLATFORM 0x400
 

--- a/basebinaries/jailbreakd/kern_utils.m
+++ b/basebinaries/jailbreakd/kern_utils.m
@@ -126,7 +126,7 @@ uint64_t find_port(mach_port_name_t port){
                 uint32_t SetObjectWithCharP = 8*31;
 #define OSDictionary_SetItem(dict, str, val) {\
 uint64_t s = kalloc(strlen(str)+1); kwrite(s, str, strlen(str)); \
-kexecute(user_client, fake_client, rk64(rk64(dict)+SetObjectWithCharP), dict, s, val, 0, 0, 0, 0); \
+kexecute(rk64(rk64(dict)+SetObjectWithCharP), dict, s, val, 0, 0, 0, 0); \
 kfree(s, strlen(str)+1); \
             }
 #define OSString_CStringPtr(str) rk64(str+0x10)
@@ -249,7 +249,7 @@ void set_amfi_entitlements(uint64_t proc) {
     /*for (int idx = 0; idx < OSDictionary_ItemCount(amfi_entitlements); idx++) {
         uint64_t key = OSDictionary_ItemKey(OSDictionary_ItemBuffer(amfi_entitlements), idx);
         uint64_t keyOSStr = OSString_CStringPtr(key);
-        size_t length = kexecute(user_client, fake_client, 0xFFFFFFF00709BDE0+kernel_slide, keyOSStr, 0, 0, 0, 0, 0, 0); //strlen
+        size_t length = kexecute(0xFFFFFFF00709BDE0+kernel_slide, keyOSStr, 0, 0, 0, 0, 0, 0); //strlen
         char* s = (char*)calloc(length+1, 1);
         kread(keyOSStr, s, length);
         NSLog(@"Entitlement: %s", s);

--- a/basebinaries/jailbreakd/kexecute.c
+++ b/basebinaries/jailbreakd/kexecute.c
@@ -2,8 +2,7 @@
 #include "kexecute.h"
 #include "kern_utils.h"
 #include "patchfinder64.h"
-
-static unsigned offsetof_ip_kobject = 0x68;          // ipc_port_t::ip_kobject
+#include "offsetof.h"
 
 mach_port_t prepare_user_client(void) {
   kern_return_t err;

--- a/basebinaries/jailbreakd/kexecute.c
+++ b/basebinaries/jailbreakd/kexecute.c
@@ -1,0 +1,55 @@
+#include "kmem.h"
+#include "kexecute.h"
+#include "kern_utils.h"
+
+mach_port_t prepare_user_client(void) {
+  kern_return_t err;
+  mach_port_t user_client;
+  io_service_t service = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOSurfaceRoot"));
+  
+  if (service == IO_OBJECT_NULL){
+    printf(" [-] unable to find service\n");
+    exit(EXIT_FAILURE);
+  }
+  
+  err = IOServiceOpen(service, mach_task_self(), 0, &user_client);
+  if (err != KERN_SUCCESS){
+    printf(" [-] unable to get user client connection\n");
+    exit(EXIT_FAILURE);
+  }
+  
+  
+  printf("got user client: 0x%x\n", user_client);
+  return user_client;
+}
+
+int kexecute_lock = 0;
+
+uint64_t kexecute(mach_port_t user_client, uint64_t fake_client, uint64_t addr, uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5, uint64_t x6) {
+    while (kexecute_lock){
+      printf("Kexecute locked. Waiting for 10ms.");
+      usleep(10000);
+    }
+
+    kexecute_lock = 1;
+
+    // When calling IOConnectTrapX, this makes a call to iokit_user_client_trap, which is the user->kernel call (MIG). This then calls IOUserClient::getTargetAndTrapForIndex
+    // to get the trap struct (which contains an object and the function pointer itself). This function calls IOUserClient::getExternalTrapForIndex, which is expected to return a trap.
+    // This jumps to our gadget, which returns +0x40 into our fake user_client, which we can modify. The function is then called on the object. But how C++ actually works is that the
+    // function is called with the first arguement being the object (referenced as `this`). Because of that, the first argument of any function we call is the object, and everything else is passed
+    // through like normal.
+    
+    // Because the gadget gets the trap at user_client+0x40, we have to overwrite the contents of it
+    // We will pull a switch when doing so - retrieve the current contents, call the trap, put back the contents
+    // (i'm not actually sure if the switch back is necessary but meh)
+    
+    uint64_t offx20 = rk64(fake_client+0x40);
+    uint64_t offx28 = rk64(fake_client+0x48);
+    wk64(fake_client+0x40, x0);
+    wk64(fake_client+0x48, addr);
+    uint64_t returnval = IOConnectTrap6(user_client, 0, (uint64_t)(x1), (uint64_t)(x2), (uint64_t)(x3), (uint64_t)(x4), (uint64_t)(x5), (uint64_t)(x6));
+    wk64(fake_client+0x40, offx20);
+    wk64(fake_client+0x48, offx28);
+    kexecute_lock = 0;
+    return returnval;
+}

--- a/basebinaries/jailbreakd/kexecute.h
+++ b/basebinaries/jailbreakd/kexecute.h
@@ -1,0 +1,8 @@
+#include <mach/mach.h>
+#include <inttypes.h>
+
+extern mach_port_t user_client;
+extern uint64_t fake_client;
+
+uint64_t kexecute(mach_port_t user_client, uint64_t fake_client, uint64_t addr, uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5, uint64_t x6);
+mach_port_t prepare_user_client(void);

--- a/basebinaries/jailbreakd/kexecute.h
+++ b/basebinaries/jailbreakd/kexecute.h
@@ -1,8 +1,6 @@
 #include <mach/mach.h>
 #include <inttypes.h>
 
-extern mach_port_t user_client;
-extern uint64_t fake_client;
-
-uint64_t kexecute(mach_port_t user_client, uint64_t fake_client, uint64_t addr, uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5, uint64_t x6);
-mach_port_t prepare_user_client(void);
+uint64_t kexecute(uint64_t addr, uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5, uint64_t x6);
+void init_kexecute(void);
+void term_kexecute(void);

--- a/basebinaries/jailbreakd/kmem.c
+++ b/basebinaries/jailbreakd/kmem.c
@@ -69,3 +69,37 @@ void wk32(uint64_t kaddr, uint32_t val) {
 void wk64(uint64_t kaddr, uint64_t val) {
   kwrite(kaddr, &val, sizeof(val));
 }
+
+// thx Siguza
+typedef struct {
+  uint64_t prev;
+  uint64_t next;
+  uint64_t start;
+  uint64_t end;
+} kmap_hdr_t;
+
+uint64_t zm_fix_addr(uint64_t addr) {
+  static kmap_hdr_t zm_hdr = {0, 0, 0, 0};
+
+  if (zm_hdr.start == 0) {
+    // xxx rk64(0) ?!
+    uint64_t zone_map = rk64(find_zone_map_ref());
+    // hdr is at offset 0x10, mutexes at start
+    size_t r = kread(zone_map + 0x10, &zm_hdr, sizeof(zm_hdr));
+    printf("zm_range: 0x%llx - 0x%llx (read 0x%zx, exp 0x%zx)\n", zm_hdr.start, zm_hdr.end, r, sizeof(zm_hdr));
+
+    if (r != sizeof(zm_hdr) || zm_hdr.start == 0 || zm_hdr.end == 0) {
+      printf("kread of zone_map failed!\n");
+      exit(1);
+    }
+
+    if (zm_hdr.end - zm_hdr.start > 0x100000000) {
+        printf("zone_map is too big, sorry.\n");
+        exit(1);
+    }
+  }
+
+  uint64_t zm_tmp = (zm_hdr.start & 0xffffffff00000000) | ((addr) & 0xffffffff);
+
+  return zm_tmp < zm_hdr.start ? zm_tmp + 0x100000000 : zm_tmp;
+}

--- a/basebinaries/jailbreakd/kmem.c
+++ b/basebinaries/jailbreakd/kmem.c
@@ -1,0 +1,71 @@
+#import "kern_utils.h"
+#import "patchfinder64.h"
+#import "kmem.h"
+
+#define MAX_CHUNK_SIZE 0xFFF
+
+size_t kread(uint64_t where, void *p, size_t size) {
+	int rv;
+	size_t offset = 0;
+	while (offset < size) {
+		mach_vm_size_t sz, chunk = MAX_CHUNK_SIZE;
+		if (chunk > size - offset) {
+			chunk = size - offset;
+		}
+		rv = mach_vm_read_overwrite(tfpzero, where + offset, chunk, (mach_vm_address_t)p + offset, &sz);
+		if (rv || sz == 0) {
+			fprintf(stderr, "[e] error reading kernel @%p\n", (void *)(offset + where));
+			break;
+		}
+		offset += sz;
+	}
+	return offset;
+}
+
+size_t kwrite(uint64_t where, const void *p, size_t size) {
+	int rv;
+	size_t offset = 0;
+	while (offset < size) {
+		size_t chunk = MAX_CHUNK_SIZE;
+		if (chunk > size - offset) {
+			chunk = size - offset;
+		}
+		rv = mach_vm_write(tfpzero, where + offset, (mach_vm_offset_t)p + offset, chunk);
+		if (rv) {
+			fprintf(stderr, "[e] error writing kernel @%p\n", (void *)(offset + where));
+			break;
+		}
+		offset += chunk;
+	}
+	return offset;
+}
+
+uint64_t kalloc(vm_size_t size){
+	mach_vm_address_t address = 0;
+	mach_vm_allocate(tfpzero, (mach_vm_address_t *)&address, size, VM_FLAGS_ANYWHERE);
+	return address;
+}
+
+void kfree(mach_vm_address_t address, vm_size_t size){
+  mach_vm_deallocate(tfpzero, address, size);
+}
+
+uint32_t rk32(uint64_t kaddr) {
+  uint32_t val = 0;
+  kread(kaddr, &val, sizeof(val));
+  return val;
+}
+
+uint64_t rk64(uint64_t kaddr) {
+  uint64_t val = 0;
+  kread(kaddr, &val, sizeof(val));
+  return val;
+}
+
+void wk32(uint64_t kaddr, uint32_t val) {
+  kwrite(kaddr, &val, sizeof(val));
+}
+
+void wk64(uint64_t kaddr, uint64_t val) {
+  kwrite(kaddr, &val, sizeof(val));
+}

--- a/basebinaries/jailbreakd/kmem.h
+++ b/basebinaries/jailbreakd/kmem.h
@@ -1,0 +1,12 @@
+#include <mach/mach.h>
+
+uint64_t kalloc(vm_size_t size);
+void kfree(mach_vm_address_t address, vm_size_t size);
+
+size_t kread(uint64_t where, void *p, size_t size);
+uint32_t rk32(uint64_t kaddr);
+uint64_t rk64(uint64_t kaddr);
+
+size_t kwrite(uint64_t where, const void *p, size_t size);
+void wk32(uint64_t kaddr, uint32_t val);
+void wk64(uint64_t kaddr, uint64_t val);

--- a/basebinaries/jailbreakd/kmem.h
+++ b/basebinaries/jailbreakd/kmem.h
@@ -10,3 +10,5 @@ uint64_t rk64(uint64_t kaddr);
 size_t kwrite(uint64_t where, const void *p, size_t size);
 void wk32(uint64_t kaddr, uint32_t val);
 void wk64(uint64_t kaddr, uint64_t val);
+
+uint64_t zm_fix_addr(uint64_t addr);

--- a/basebinaries/jailbreakd/main.m
+++ b/basebinaries/jailbreakd/main.m
@@ -51,9 +51,6 @@ mach_port_t tfpzero;
 uint64_t kernel_base;
 uint64_t kernel_slide;
 
-mach_port_t user_client;
-uint64_t fake_client;
-
 #define MEMORYSTATUS_CMD_SET_JETSAM_TASK_LIMIT 6
 int memorystatus_control(uint32_t command, int32_t pid, uint32_t flags, void *buffer, size_t buffersize);
 
@@ -82,55 +79,7 @@ int runserver(){
     kernel_slide = kernel_base - 0xFFFFFFF007004000;
     NSLog(@"[jailbreakd] slide: 0x%016llx", kernel_slide);
 
-    user_client = prepare_user_client();
-
-    // From v0rtex - get the IOSurfaceRootUserClient port, and then the address of the actual client, and vtable
-    uint64_t IOSurfaceRootUserClient_port = find_port(user_client); // UserClients are just mach_ports, so we find its address
-    NSLog(@"Found port: 0x%llx", IOSurfaceRootUserClient_port);
-
-    uint64_t IOSurfaceRootUserClient_addr = rk64(IOSurfaceRootUserClient_port + offsetof_ip_kobject); // The UserClient itself (the C++ object) is at the kobject field
-    NSLog(@"Found addr: 0x%llx", IOSurfaceRootUserClient_addr);
-
-    uint64_t IOSurfaceRootUserClient_vtab = rk64(IOSurfaceRootUserClient_addr); // vtables in C++ are at *object
-    NSLog(@"Found vtab: 0x%llx", IOSurfaceRootUserClient_vtab);
-
-    // The aim is to create a fake client, with a fake vtable, and overwrite the existing client with the fake one
-    // Once we do that, we can use IOConnectTrap6 to call functions in the kernel as the kernel
-
-
-    // Create the vtable in the kernel memory, then copy the existing vtable into there
-    uint64_t fake_vtable = kalloc(0x1000);
-    NSLog(@"Created fake_vtable at %016llx", fake_vtable);
-
-    for (int i = 0; i < 0x200; i++) {
-        wk64(fake_vtable+i*8, rk64(IOSurfaceRootUserClient_vtab+i*8));
-    }
-
-    NSLog(@"Copied some of the vtable over");
-
-
-    // Create the fake user client
-    fake_client = kalloc(0x1000);
-    NSLog(@"Created fake_client at %016llx", fake_client);
-
-    for (int i = 0; i < 0x200; i++) {
-        wk64(fake_client+i*8, rk64(IOSurfaceRootUserClient_addr+i*8));
-    }
-
-    NSLog(@"Copied the user client over");
-
-    // Write our fake vtable into the fake user client
-    wk64(fake_client, fake_vtable);
-
-    // Replace the user client with ours
-    wk64(IOSurfaceRootUserClient_port + offsetof_ip_kobject, fake_client);
-
-    // Now the userclient port we have will look into our fake user client rather than the old one
-
-    // Replace IOUserClient::getExternalTrapForIndex with our ROP gadget (add x0, x0, #0x40; ret;)
-    wk64(fake_vtable+8*0xB7, find_add_x0_x0_0x40_ret());
-
-    NSLog(@"Wrote the `add x0, x0, #0x40; ret;` gadget over getExternalTrapForIndex");
+    init_kexecute();
 
     struct sockaddr_in serveraddr; /* server's addr */
     struct sockaddr_in clientaddr; /* client addr */
@@ -160,7 +109,8 @@ int runserver(){
 
     if (bind(sockfd, (struct sockaddr *)&serveraddr, sizeof(serveraddr)) < 0){
         NSLog(@"[jailbreakd] Error binding...");
-        wk64(IOSurfaceRootUserClient_port + offsetof_ip_kobject, IOSurfaceRootUserClient_addr);
+        term_kernel();
+        term_kexecute();
         exit(-1);
     }
     NSLog(@"[jailbreakd] Server running!");
@@ -242,7 +192,8 @@ int runserver(){
         }
         if (command == JAILBREAKD_COMMAND_EXIT){
             NSLog(@"Got Exit Command! Goodbye!");
-            wk64(IOSurfaceRootUserClient_port + offsetof_ip_kobject, IOSurfaceRootUserClient_addr);
+            term_kernel();
+            term_kexecute();
             exit(0);
         }
     }

--- a/basebinaries/jailbreakd/main.m
+++ b/basebinaries/jailbreakd/main.m
@@ -13,6 +13,7 @@
 #include "patchfinder64.h"
 #include "kern_utils.h"
 #include "kmem.h"
+#include "kexecute.h"
 
 #define JAILBREAKD_COMMAND_ENTITLE 1
 #define JAILBREAKD_COMMAND_ENTITLE_AND_SIGCONT 2

--- a/basebinaries/jailbreakd/main.m
+++ b/basebinaries/jailbreakd/main.m
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include "patchfinder64.h"
 #include "kern_utils.h"
+#include "kmem.h"
 
 #define JAILBREAKD_COMMAND_ENTITLE 1
 #define JAILBREAKD_COMMAND_ENTITLE_AND_SIGCONT 2

--- a/basebinaries/jailbreakd/offsetof.c
+++ b/basebinaries/jailbreakd/offsetof.c
@@ -1,0 +1,42 @@
+
+unsigned offsetof_p_pid = 0x10;               // proc_t::p_pid
+unsigned offsetof_task = 0x18;                // proc_t::task
+unsigned offsetof_p_uid = 0x30;               // proc_t::p_uid
+unsigned offsetof_p_gid = 0x34;               // proc_t::p_uid
+unsigned offsetof_p_ruid = 0x38;              // proc_t::p_uid
+unsigned offsetof_p_rgid = 0x3c;              // proc_t::p_uid
+unsigned offsetof_p_ucred = 0x100;            // proc_t::p_ucred
+unsigned offsetof_p_csflags = 0x2a8;          // proc_t::p_csflags
+unsigned offsetof_itk_self = 0xD8;            // task_t::itk_self (convert_task_to_port)
+unsigned offsetof_itk_sself = 0xE8;           // task_t::itk_sself (task_get_special_port)
+unsigned offsetof_itk_bootstrap = 0x2b8;      // task_t::itk_bootstrap (task_get_special_port)
+unsigned offsetof_itk_space = 0x308;          // task_t::itk_space
+unsigned offsetof_ip_mscount = 0x9C;          // ipc_port_t::ip_mscount (ipc_port_make_send)
+unsigned offsetof_ip_srights = 0xA0;          // ipc_port_t::ip_srights (ipc_port_make_send)
+unsigned offsetof_ip_kobject = 0x68;          // ipc_port_t::ip_kobject
+unsigned offsetof_p_textvp = 0x248;           // proc_t::p_textvp
+unsigned offsetof_p_textoff = 0x250;          // proc_t::p_textoff
+unsigned offsetof_p_cputype = 0x2c0;          // proc_t::p_cputype
+unsigned offsetof_p_cpu_subtype = 0x2c4;      // proc_t::p_cpu_subtype
+unsigned offsetof_special = 2 * sizeof(long); // host::special
+unsigned offsetof_ipc_space_is_table = 0x20;  // ipc_space::is_table?..
+
+unsigned offsetof_ucred_cr_uid = 0x18;        // ucred::cr_uid
+unsigned offsetof_ucred_cr_ruid = 0x1c;       // ucred::cr_ruid
+unsigned offsetof_ucred_cr_svuid = 0x20;      // ucred::cr_svuid
+
+unsigned offsetof_v_type = 0x70;              // vnode::v_type
+unsigned offsetof_v_id = 0x74;                // vnode::v_id
+unsigned offsetof_v_ubcinfo = 0x78;           // vnode::v_ubcinfo
+
+unsigned offsetof_ubcinfo_csblobs = 0x50;     // ubc_info::csblobs
+
+unsigned offsetof_csb_cputype = 0x8;          // cs_blob::csb_cputype
+unsigned offsetof_csb_flags = 0x12;           // cs_blob::csb_flags
+unsigned offsetof_csb_base_offset = 0x16;     // cs_blob::csb_base_offset
+unsigned offsetof_csb_entitlements_offset = 0x98; // cs_blob::csb_entitlements
+unsigned offsetof_csb_signer_type = 0xA0;     // cs_blob::csb_signer_type
+unsigned offsetof_csb_platform_binary = 0xA4; // cs_blob::csb_platform_binary
+unsigned offsetof_csb_platform_path = 0xA8;   // cs_blob::csb_platform_path
+
+unsigned offsetof_t_flags = 0x3a0; // task::t_flags

--- a/basebinaries/jailbreakd/offsetof.h
+++ b/basebinaries/jailbreakd/offsetof.h
@@ -1,0 +1,41 @@
+extern unsigned offsetof_p_pid;
+extern unsigned offsetof_task;
+extern unsigned offsetof_p_uid;
+extern unsigned offsetof_p_gid;
+extern unsigned offsetof_p_ruid;
+extern unsigned offsetof_p_rgid;
+extern unsigned offsetof_p_ucred;
+extern unsigned offsetof_p_csflags;
+extern unsigned offsetof_itk_self;
+extern unsigned offsetof_itk_sself;
+extern unsigned offsetof_itk_bootstrap;
+extern unsigned offsetof_itk_space;
+extern unsigned offsetof_ip_mscount;
+extern unsigned offsetof_ip_srights;
+extern unsigned offsetof_ip_kobject;
+extern unsigned offsetof_p_textvp;
+extern unsigned offsetof_p_textoff;
+extern unsigned offsetof_p_cputype;
+extern unsigned offsetof_p_cpu_subtype;
+extern unsigned offsetof_special;
+extern unsigned offsetof_ipc_space_is_table;
+
+extern unsigned offsetof_ucred_cr_uid;
+extern unsigned offsetof_ucred_cr_ruid;
+extern unsigned offsetof_ucred_cr_svuid;
+
+extern unsigned offsetof_v_type;
+extern unsigned offsetof_v_id;
+extern unsigned offsetof_v_ubcinfo;
+
+extern unsigned offsetof_ubcinfo_csblobs;
+
+extern unsigned offsetof_csb_cputype;
+extern unsigned offsetof_csb_flags;
+extern unsigned offsetof_csb_base_offset;
+extern unsigned offsetof_csb_entitlements_offset;
+extern unsigned offsetof_csb_signer_type;
+extern unsigned offsetof_csb_platform_binary;
+extern unsigned offsetof_csb_platform_path;
+
+extern unsigned offsetof_t_flags;

--- a/basebinaries/jailbreakd/osobject.c
+++ b/basebinaries/jailbreakd/osobject.c
@@ -9,6 +9,10 @@ static uint32_t off_OSDictionary_Merge              = sizeof(void*) * 0x23;
 
 static uint32_t off_OSArray_Merge                   = sizeof(void*) * 0x1E;
 
+static uint32_t off_OSObject_Release                = sizeof(void*) * 0x05;
+static uint32_t off_OSObject_GetRetainCount         = sizeof(void*) * 0x03;
+static uint32_t off_OSObject_Retain                 = sizeof(void*) * 0x04;
+
 // 1 on success, 0 on error
 int OSDictionary_SetItem(uint64_t dict, const char *key, uint64_t val) {
 	size_t len = strlen(key) + 1;
@@ -98,4 +102,20 @@ uint64_t OSUnserializeXML(const char* buffer) {
 	}
 
 	return ret;
+}
+
+void OSObject_Release(uint64_t osobject) {
+	uint64_t vtab = rk64(osobject);
+	uint64_t f = rk64(vtab + off_OSObject_Release);
+	(void) kexecute(f, osobject, 0, 0, 0, 0, 0, 0);
+}
+
+void OSObject_Retain(uint64_t osobject) {
+	uint64_t vtab = rk64(osobject);
+	uint64_t f = rk64(vtab + off_OSObject_Release);
+	(void) kexecute(f, osobject, 0, 0, 0, 0, 0, 0);
+}
+
+uint64_t OSObject_GetRetainCount(uint64_t osobject) {
+
 }

--- a/basebinaries/jailbreakd/osobject.c
+++ b/basebinaries/jailbreakd/osobject.c
@@ -116,6 +116,8 @@ void OSObject_Retain(uint64_t osobject) {
 	(void) kexecute(f, osobject, 0, 0, 0, 0, 0, 0);
 }
 
-uint64_t OSObject_GetRetainCount(uint64_t osobject) {
-
+uint32_t OSObject_GetRetainCount(uint64_t osobject) {
+	uint64_t vtab = rk64(osobject);
+	uint64_t f = rk64(vtab + off_OSObject_Release);
+	return (uint32_t) kexecute(f, osobject, 0, 0, 0, 0, 0, 0);
 }

--- a/basebinaries/jailbreakd/osobject.c
+++ b/basebinaries/jailbreakd/osobject.c
@@ -1,0 +1,101 @@
+#include "kexecute.h"
+#include "kmem.h"
+#include "patchfinder64.h"
+
+// offsets in vtable:
+static uint32_t off_OSDictionary_SetObjectWithCharP = sizeof(void*) * 0x1F;
+static uint32_t off_OSDictionary_GetObjectWithCharP = sizeof(void*) * 0x26;
+static uint32_t off_OSDictionary_Merge              = sizeof(void*) * 0x23;
+
+static uint32_t off_OSArray_Merge                   = sizeof(void*) * 0x1E;
+
+// 1 on success, 0 on error
+int OSDictionary_SetItem(uint64_t dict, const char *key, uint64_t val) {
+	size_t len = strlen(key) + 1;
+
+	uint64_t ks = kalloc(len);
+	kwrite(ks, key, len);
+
+	uint64_t vtab = rk64(dict);
+	uint64_t f = rk64(vtab + off_OSDictionary_SetObjectWithCharP);
+
+	int rv = (int) kexecute(f, dict, ks, val, 0, 0, 0, 0);
+
+	kfree(ks, len);
+
+	return rv;
+}
+
+// XXX it can return 0 in lower 32 bits but still be valid
+// fix addr of returned value and check if rk64 gives ptr
+// to vtable addr saved before
+
+// address if exists, 0 if not
+uint64_t _OSDictionary_GetItem(uint64_t dict, const char *key) {
+	size_t len = strlen(key) + 1;
+
+	uint64_t ks = kalloc(len);
+	kwrite(ks, key, len);
+
+	uint64_t vtab = rk64(dict);
+	uint64_t f = rk64(vtab + off_OSDictionary_GetObjectWithCharP);
+
+	int rv = (int) kexecute(f, dict, ks, 0, 0, 0, 0, 0);
+
+	kfree(ks, len);
+
+	return rv;
+}
+
+uint64_t OSDictionary_GetItem(uint64_t dict, const char *key) {
+	uint64_t ret = _OSDictionary_GetItem(dict, key);
+	
+	if (ret != 0) {
+		// XXX can it be not in zalloc?..
+		ret = zm_fix_addr(ret);
+	}
+
+	return ret;
+}
+
+// 1 on success, 0 on error
+int OSDictionary_Merge(uint64_t dict, uint64_t aDict) {
+	uint64_t vtab = rk64(dict);
+	uint64_t f = rk64(vtab + off_OSDictionary_Merge);
+
+	return (int) kexecute(f, dict, aDict, 0, 0, 0, 0, 0);
+}
+
+// 1 on success, 0 on error
+int OSArray_Merge(uint64_t array, uint64_t aArray) {
+	uint64_t vtab = rk64(array);
+	uint64_t f = rk64(vtab + off_OSArray_Merge);
+
+	return (int) kexecute(f, array, aArray, 0, 0, 0, 0, 0);
+}
+
+// XXX error handling just for fun? :)
+uint64_t _OSUnserializeXML(const char* buffer) {
+	size_t len = strlen(buffer) + 1;
+
+	uint64_t ks = kalloc(len);
+	kwrite(ks, buffer, len);
+
+	uint64_t errorptr = 0;
+
+	uint64_t rv = kexecute(find_osunserializexml(), ks, errorptr, 0, 0, 0, 0, 0);
+	kfree(ks, len);
+
+	return rv;
+}
+
+uint64_t OSUnserializeXML(const char* buffer) {
+	uint64_t ret = _OSUnserializeXML(buffer);
+	
+	if (ret != 0) {
+		// XXX can it be not in zalloc?..
+		ret = zm_fix_addr(ret);
+	}
+
+	return ret;
+}

--- a/basebinaries/jailbreakd/osobject.h
+++ b/basebinaries/jailbreakd/osobject.h
@@ -1,0 +1,13 @@
+#define OSDictionary_ItemCount(dict) rk32(dict+20)
+#define OSDictionary_ItemBuffer(dict) rk64(dict+32)
+#define OSDictionary_ItemKey(buffer, idx) rk64(buffer+16*idx)
+#define OSDictionary_ItemValue(buffer, idx) rk64(buffer+16*idx+8)
+#define OSString_CStringPtr(str) rk64(str + 0x10)
+
+// see osobject.c for info
+
+int OSDictionary_SetItem(uint64_t dict, const char *key, uint64_t val);
+uint64_t OSDictionary_GetItem(uint64_t dict, const char *key);
+int OSDictionary_Merge(uint64_t dict, uint64_t aDict);
+int OSArray_Merge(uint64_t array, uint64_t aArray);
+uint64_t OSUnserializeXML(const char* buffer);

--- a/basebinaries/jailbreakd/osobject.h
+++ b/basebinaries/jailbreakd/osobject.h
@@ -3,6 +3,7 @@
 #define OSDictionary_ItemKey(buffer, idx) rk64(buffer+16*idx)
 #define OSDictionary_ItemValue(buffer, idx) rk64(buffer+16*idx+8)
 #define OSString_CStringPtr(str) rk64(str + 0x10)
+#define OSArray_ItemCount(arr) rk32(arr+0x14)
 
 // see osobject.c for info
 
@@ -11,3 +12,7 @@ uint64_t OSDictionary_GetItem(uint64_t dict, const char *key);
 int OSDictionary_Merge(uint64_t dict, uint64_t aDict);
 int OSArray_Merge(uint64_t array, uint64_t aArray);
 uint64_t OSUnserializeXML(const char* buffer);
+
+void OSObject_Release(uint64_t osobject);
+void OSObject_Retain(uint64_t osobject);
+uint32_t OSObject_GetRetainCount(uint64_t osobject);

--- a/basebinaries/jailbreakd/patchfinder64.c
+++ b/basebinaries/jailbreakd/patchfinder64.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "patchfinder64.h"
+#include "kmem.h"
 
 #define CACHED_FIND_UINT64(name) CACHED_FIND(uint64_t, name)
 

--- a/basebinaries/jailbreakd/patchfinder64.c
+++ b/basebinaries/jailbreakd/patchfinder64.c
@@ -820,5 +820,5 @@ CACHED_FIND_UINT64(find_osunserializexml) {
     addr_t ref = find_strref("OSUnserializeXML: %s near line %d\n", 1, 0);
     ref -= kerndumpbase;
     uint64_t start = bof64(kernel, xnucore_base, ref);
-    return start;
+    return start + kerndumpbase;
 }

--- a/basebinaries/jailbreakd/patchfinder64.c
+++ b/basebinaries/jailbreakd/patchfinder64.c
@@ -624,6 +624,7 @@ term_kernel(void)
 #define INSN_CALL 0x94000000, 0xFC000000
 #define INSN_B    0x14000000, 0xFC000000
 #define INSN_CBZ  0x34000000, 0xFC000000
+#define INSN_ADRP 0x90000000, 0x9F000000
 
 addr_t
 find_register_value(addr_t where, int reg)
@@ -776,4 +777,48 @@ CACHED_FIND_UINT64(find_OSBoolean_True) {
 
 CACHED_FIND_UINT64(find_OSBoolean_False) {
     return find_OSBoolean_True()+8;
+}
+
+CACHED_FIND_UINT64(find_zone_map_ref) {
+    // \"Nothing being freed to the zone_map. start = end = %p\\n\"
+    uint64_t val = kerndumpbase;
+
+    addr_t ref = find_strref("\"Nothing being freed to the zone_map. start = end = %p\\n\"", 1, 0);
+    ref -= kerndumpbase;
+
+    // skip add & adrp for panic str
+    ref -= 8;
+
+    // adrp xX, #_zone_map@PAGE
+    ref = step64_back(kernel, ref, 30, INSN_ADRP);
+
+    uint32_t *insn = (uint32_t*)(kernel+ref);
+    // get pc
+    val += ((uint8_t*)(insn) - kernel) & ~0xfff;
+    uint8_t xm = *insn & 0x1f;
+
+    // don't ask, I wrote this at 5am
+    val += (*insn<<9 & 0x1ffffc000) | (*insn>>17 & 0x3000);
+
+    // ldr x, [xX, #_zone_map@PAGEOFF]
+    ++insn;
+    if ((*insn & 0xF9C00000) != 0xF9400000) {
+        return 0;
+    }
+
+    // xd == xX, xn == xX,
+    if ((*insn&0x1f) != xm || ((*insn>>5)&0x1f) != xm) {
+        return 0;
+    }
+
+    val += ((*insn >> 10) & 0xFFF) << 3;
+
+    return val;
+}
+
+CACHED_FIND_UINT64(find_osunserializexml) {
+    addr_t ref = find_strref("OSUnserializeXML: %s near line %d\n", 1, 0);
+    ref -= kerndumpbase;
+    uint64_t start = bof64(kernel, xnucore_base, ref);
+    return start;
 }

--- a/basebinaries/jailbreakd/patchfinder64.h
+++ b/basebinaries/jailbreakd/patchfinder64.h
@@ -20,5 +20,7 @@ uint64_t find_allproc(void);
 uint64_t find_add_x0_x0_0x40_ret(void);
 uint64_t find_OSBoolean_True(void);
 uint64_t find_OSBoolean_False(void);
+uint64_t find_zone_map_ref(void);
+uint64_t find_osunserializexml(void);
 
 #endif

--- a/basebinaries/jailbreakd/patchfinder64.h
+++ b/basebinaries/jailbreakd/patchfinder64.h
@@ -18,9 +18,6 @@ void term_kernel(void);
 // Fun part
 uint64_t find_allproc(void);
 uint64_t find_add_x0_x0_0x40_ret(void);
-uint64_t find_copyout(void);
-uint64_t find_bzero(void);
-uint64_t find_bcopy(void);
 uint64_t find_OSBoolean_True(void);
 uint64_t find_OSBoolean_False(void);
 

--- a/basebinaries/jailbreakd/patchfinder64.h
+++ b/basebinaries/jailbreakd/patchfinder64.h
@@ -21,9 +21,6 @@ uint64_t find_add_x0_x0_0x40_ret(void);
 uint64_t find_copyout(void);
 uint64_t find_bzero(void);
 uint64_t find_bcopy(void);
-uint64_t find_rootvnode(void);
-uint64_t find_trustcache(void);
-uint64_t find_amficache(void);
 uint64_t find_OSBoolean_True(void);
 uint64_t find_OSBoolean_False(void);
 


### PR DESCRIPTION
- Major code cleanup, splitting
- Fix #44 
- Fix #45 

Note: Apps are still unable to access paths specified in exceptions on first run.
However, according to logs, when exceptions are added for one AppStore app, it's added for all other apps too. So probably it's not because of exceptions.