### PR TITLE
XPC jailbreakd

### DIFF
--- a/basebinaries/Makefile
+++ b/basebinaries/Makefile
@@ -3,7 +3,7 @@ OUTDIR ?= bin
 
 .PHONY: all clean
 
-SUBPRJ = amfid_payload inject_criticald jailbreakd jailbreakd_client pspawn_payload
+SUBPRJ = amfid_payload inject_criticald jailbreakd jailbreakd_client pspawn_payload libjailbreak_xpc
 all: $(OUTDIR)/$(TARGET)
 
 MFLAGS = OUTDIR=$(abspath $(OUTDIR))

--- a/basebinaries/jailbreakd/Makefile
+++ b/basebinaries/jailbreakd/Makefile
@@ -3,7 +3,7 @@ OUTDIR ?= bin
 
 CC      = xcrun -sdk iphoneos cc -arch arm64
 LDID    = ldid
-CFLAGS  = -Wall -Wno-unused-variable -Wno-unused-function
+CFLAGS  = -Wall -Wno-unused-variable -Wno-unused-function -I./apple_include
 
 .PHONY: all clean
 
@@ -20,7 +20,7 @@ $(OUTDIR):
 	mkdir -p $(OUTDIR)
 
 $(OUTDIR)/$(TARGET): *.c *.m | $(OUTDIR)
-	$(CC) -o $@ $^ -framework Foundation -framework IOKit $(CFLAGS)
+	$(CC) -o $@ $^ -framework Foundation -framework IOKit -framework LocalAuthentication $(CFLAGS)
 	$(LDID) -SEnt.plist $@
 
 clean:

--- a/basebinaries/jailbreakd/apple_include
+++ b/basebinaries/jailbreakd/apple_include
@@ -1,0 +1,1 @@
+../apple_include

--- a/basebinaries/jailbreakd/kexecute.c
+++ b/basebinaries/jailbreakd/kexecute.c
@@ -1,3 +1,4 @@
+#include <pthread.h>
 #include "kmem.h"
 #include "kexecute.h"
 #include "kern_utils.h"
@@ -8,24 +9,25 @@ mach_port_t prepare_user_client(void) {
   kern_return_t err;
   mach_port_t user_client;
   io_service_t service = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOSurfaceRoot"));
-  
+
   if (service == IO_OBJECT_NULL){
     printf(" [-] unable to find service\n");
     exit(EXIT_FAILURE);
   }
-  
+
   err = IOServiceOpen(service, mach_task_self(), 0, &user_client);
   if (err != KERN_SUCCESS){
     printf(" [-] unable to get user client connection\n");
     exit(EXIT_FAILURE);
   }
-  
-  
+
+
   printf("got user client: 0x%x\n", user_client);
   return user_client;
 }
 
-static int kexecute_lock = 0;
+// TODO: Consider removing this - jailbreakd runs all kernel ops on the main thread
+pthread_mutex_t kexecute_lock;
 static mach_port_t user_client;
 static uint64_t IOSurfaceRootUserClient_port;
 static uint64_t IOSurfaceRootUserClient_addr;
@@ -82,6 +84,8 @@ void init_kexecute(void) {
     wk64(fake_vtable+8*0xB7, find_add_x0_x0_0x40_ret());
 
     printf("Wrote the `add x0, x0, #0x40; ret;` gadget over getExternalTrapForIndex");
+
+    pthread_mutex_init(&kexecute_lock, NULL);
 }
 
 void term_kexecute(void) {
@@ -91,23 +95,18 @@ void term_kexecute(void) {
 }
 
 uint64_t kexecute(uint64_t addr, uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5, uint64_t x6) {
-    while (kexecute_lock){
-      printf("Kexecute locked. Waiting for 10ms.");
-      usleep(10000);
-    }
-
-    kexecute_lock = 1;
+    pthread_mutex_lock(&kexecute_lock);
 
     // When calling IOConnectTrapX, this makes a call to iokit_user_client_trap, which is the user->kernel call (MIG). This then calls IOUserClient::getTargetAndTrapForIndex
     // to get the trap struct (which contains an object and the function pointer itself). This function calls IOUserClient::getExternalTrapForIndex, which is expected to return a trap.
     // This jumps to our gadget, which returns +0x40 into our fake user_client, which we can modify. The function is then called on the object. But how C++ actually works is that the
     // function is called with the first arguement being the object (referenced as `this`). Because of that, the first argument of any function we call is the object, and everything else is passed
     // through like normal.
-    
+
     // Because the gadget gets the trap at user_client+0x40, we have to overwrite the contents of it
     // We will pull a switch when doing so - retrieve the current contents, call the trap, put back the contents
     // (i'm not actually sure if the switch back is necessary but meh)
-    
+
     uint64_t offx20 = rk64(fake_client+0x40);
     uint64_t offx28 = rk64(fake_client+0x48);
     wk64(fake_client+0x40, x0);
@@ -115,6 +114,8 @@ uint64_t kexecute(uint64_t addr, uint64_t x0, uint64_t x1, uint64_t x2, uint64_t
     uint64_t returnval = IOConnectTrap6(user_client, 0, (uint64_t)(x1), (uint64_t)(x2), (uint64_t)(x3), (uint64_t)(x4), (uint64_t)(x5), (uint64_t)(x6));
     wk64(fake_client+0x40, offx20);
     wk64(fake_client+0x48, offx28);
-    kexecute_lock = 0;
+
+    pthread_mutex_unlock(&kexecute_lock);
+
     return returnval;
 }

--- a/basebinaries/jailbreakd/main.m
+++ b/basebinaries/jailbreakd/main.m
@@ -284,7 +284,18 @@ int main(int argc, char **argv, char **envp) {
     // Get the slide
     kernel_slide = kernel_base - 0xFFFFFFF007004000;
     NSLog(@"jailbreakd: slide: 0x%016llx", kernel_slide);
+
+    // prime offset caches
+    find_allproc();
+    find_add_x0_x0_0x40_ret();
+    find_OSBoolean_True();
+    find_OSBoolean_False();
+    find_zone_map_ref();
+    find_osunserializexml();
+    find_smalloc();
     init_kexecute();
+
+    term_kernel();
 
     @autoreleasepool {
         /* About concurrency:

--- a/basebinaries/jailbreakd/main.m
+++ b/basebinaries/jailbreakd/main.m
@@ -90,7 +90,7 @@ static void do_entp_stuff_with_pid(uint64_t stuff, pid_t pid, void(^finish)(uint
 
         /* see below! */
         if ((stuff & FLAG_WAIT_EXEC) == 0) {
-            dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
                 finish(stuff, pid);
             });
         }
@@ -127,14 +127,14 @@ static void do_entp_stuff_with_pid(uint64_t stuff, pid_t pid, void(^finish)(uint
 
         /* hack: the pspawn payload won't exec until we reply, so just for
            FLAG_XPCPROXY, we'll pretend the operation completed before it actually does */
-        dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
             finish(stuff, pid);
         });
     }
 
     if (stuff & FLAG_DELAY) {
         dispatch_group_enter(waitgroup);
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
             dispatch_group_leave(waitgroup);
         });
     }

--- a/basebinaries/jailbreakd/main.m
+++ b/basebinaries/jailbreakd/main.m
@@ -1,59 +1,12 @@
 #import <Foundation/Foundation.h>
-#include <stdio.h>
-#include <mach/mach.h>
-#include <mach/error.h>
-#include <mach/message.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#include <unistd.h>
-#include "patchfinder64.h"
-#include "kern_utils.h"
-#include "kmem.h"
+#import <xpc/xpc.h>
+#import <os/log.h>
 #include "kexecute.h"
+#include "kern_utils.h"
+#include "patchfinder64.h"
 
 #define PROC_PIDPATHINFO_MAXSIZE  (4*MAXPATHLEN)
 int proc_pidpath(pid_t pid, void *buffer, uint32_t buffersize);
-
-#define JAILBREAKD_COMMAND_ENTITLE 1
-#define JAILBREAKD_COMMAND_ENTITLE_AND_SIGCONT 2
-#define JAILBREAKD_COMMAND_ENTITLE_PLATFORMIZE 3
-#define JAILBREAKD_COMMAND_ENTITLE_AND_SIGCONT_AFTER_DELAY 4
-#define JAILBREAKD_COMMAND_ENTITLE_AND_SIGCONT_FROM_XPCPROXY 5
-#define JAILBREAKD_COMMAND_FIXUP_SETUID 6
-#define JAILBREAKD_COMMAND_EXIT 13
-
-struct __attribute__((__packed__)) JAILBREAKD_PACKET {
-    uint8_t Command;
-};
-
-struct __attribute__((__packed__)) JAILBREAKD_ENTITLE_PID {
-    uint8_t Command;
-    int32_t Pid;
-};
-
-struct __attribute__((__packed__)) JAILBREAKD_ENTITLE_PID_AND_SIGCONT {
-    uint8_t Command;
-    int32_t Pid;
-};
-
-struct __attribute__((__packed__)) JAILBREAKD_FIXUP_SETUID {
-    uint8_t Command;
-    int32_t Pid;
-};
-
-struct __attribute__((__packed__)) JAILBREAKD_ENTITLE_PLATFORMIZE_PID {
-    uint8_t Command;
-    int32_t EntitlePID;
-    int32_t PlatformizePID;
-};
-
-mach_port_t tfpzero;
-uint64_t kernel_base;
-uint64_t kernel_slide;
 
 #define MEMORYSTATUS_CMD_SET_JETSAM_TASK_LIMIT 6
 int memorystatus_control(uint32_t command, int32_t pid, uint32_t flags, void *buffer, size_t buffersize);
@@ -66,10 +19,219 @@ int remove_memory_limit(void) {
     return memorystatus_control(MEMORYSTATUS_CMD_SET_JETSAM_TASK_LIMIT, my_pid, 0, NULL, 0);
 }
 
+mach_port_t tfpzero;
+uint64_t kernel_base;
+uint64_t kernel_slide;
 extern unsigned offsetof_ip_kobject;
 
-int runserver(){
-    NSLog(@"[jailbreakd] Process Start!");
+/*
+    The jailbreakd XPC protocol request:
+    {
+        "action": string, see below
+        "pid": int64
+        "flags": uint64, see below, only for entp
+    }
+
+    The reply:
+    {
+        "action": string from request
+        "pid": int64 from request
+        "result": uint64, 1 for success or 0 for failure
+    }
+
+    Bugs:
+    - the exit command doesn't reply
+    - failure currently isn't implemented so result is always 1
+*/
+
+const char *JAILBREAKD_ACTION_ENTITLE = "entp";
+const char *JAILBREAKD_ACTION_FIX_SETUID = "suid";
+const char *JAILBREAKD_ACTION_PING = "ping";
+const char *JAILBREAKD_ACTION_EXIT = "exit";
+
+/* Flags for entp command. Any combination or none can be specified. */
+/* Wait for xpcproxy to exec before continuing */
+#define FLAG_WAIT_EXEC   (1 << 5)
+/* Wait for 0.5 sec after acting */
+#define FLAG_DELAY       (1 << 4)
+/* Send SIGCONT after acting */
+#define FLAG_SIGCONT     (1 << 3)
+/* Set sandbox exception */
+#define FLAG_SANDBOX     (1 << 2)
+/* Set platform binary flag */
+#define FLAG_PLATFORMIZE (1 << 1)
+/* Set basic entitlements */
+#define FLAG_ENTITLE     (1)
+
+/* bits 0-3 */
+#define FLAG_KERN_ACTIONS_MASK (0x07)
+#define FLAG_WAITING_MASK (0x30)
+
+/* Convert the bitset specified above to a string like "eps--X" */
+static void flags_to_string(uint64_t flags, char *flgstr) {
+    const char *set = "epsCDX";
+    for (int i = 0; i < 6; ++i) {
+        if (flags & (1 << i)) {
+            flgstr[i] = set[i];
+        } else {
+            flgstr[i] = '-';
+        }
+    }
+}
+
+static void do_entp_stuff_with_pid(uint64_t stuff, pid_t pid, void(^finish)(uint64_t stuff, pid_t pid)) {
+    void (^actually_do_what_were_supposed_to)(void) = ^{
+        /* FIXME: respect flags */
+        setcsflagsandplatformize(pid);
+
+        if (stuff & FLAG_SIGCONT) {
+            kill(pid, SIGCONT);
+        }
+
+        /* see below! */
+        if ((stuff & FLAG_WAIT_EXEC) == 0) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                finish(stuff, pid);
+            });
+        }
+    };
+
+    /* skip waitgroup nonsense if we can */
+    if ((stuff & FLAG_WAITING_MASK) == 0) {
+        actually_do_what_were_supposed_to();
+        return;
+    }
+
+    /* we'll wait on both conditions at the same time */
+    dispatch_group_t waitgroup = dispatch_group_create();
+    if (stuff & FLAG_WAIT_EXEC) {
+        /* it's safe to get xpcproxy's path here --
+           pspawn_payload won't exec until later */
+        char *cmp_path = malloc(PROC_PIDPATHINFO_MAXSIZE);
+        proc_pidpath(pid, cmp_path, PROC_PIDPATHINFO_MAXSIZE);
+
+        dispatch_group_async(waitgroup, dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+            char pathbuf[PROC_PIDPATHINFO_MAXSIZE] = {0};
+
+            NSLog(@"Waiting to ensure it's not xpcproxy anymore...");
+            int ret = proc_pidpath(pid, pathbuf, sizeof(pathbuf));
+            while (ret > 0 && strcmp(pathbuf, cmp_path) == 0){
+                proc_pidpath(pid, pathbuf, sizeof(pathbuf));
+                usleep(100);
+            }
+            free(cmp_path);
+        });
+
+        /* hack: the pspawn payload won't exec until we reply, so just for
+           FLAG_XPCPROXY, we'll pretend the operation completed before it actually does */
+        dispatch_async(dispatch_get_main_queue(), ^{
+            finish(stuff, pid);
+        });
+    }
+
+    if (stuff & FLAG_DELAY) {
+        dispatch_group_enter(waitgroup);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+            dispatch_group_leave(waitgroup);
+        });
+    }
+
+    dispatch_group_notify(waitgroup, dispatch_get_main_queue(), actually_do_what_were_supposed_to);
+    dispatch_release(waitgroup);
+}
+
+static void do_suid_with_pid(pid_t pid, void(^finish)(pid_t pid)) {
+    fixupsetuid(pid);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        finish(pid);
+    });
+}
+
+static void jailbreakd_handle_xpc_connection(xpc_connection_t who) {
+    xpc_connection_set_event_handler(who, ^(xpc_object_t msg) {
+        xpc_type_t type = xpc_get_type(msg);
+        if (type == XPC_TYPE_ERROR) {
+            NSLog(@"jailbreakd: connection error %s", xpc_dictionary_get_string(msg, XPC_ERROR_KEY_DESCRIPTION));
+            return;
+        }
+
+        xpc_connection_t peer = xpc_dictionary_get_remote_connection(msg);
+
+        char *desc = xpc_copy_description(msg);
+        NSLog(@"jailbreakd: received object: %s", desc);
+        free(desc);
+
+        const char *action = xpc_dictionary_get_string(msg, "action");
+        if (!action) {
+            char *desc = xpc_copy_description(msg);
+            NSLog(@"jailbreakd: received message from pid %d with no action: %s",
+                xpc_connection_get_pid(peer),
+                desc);
+            free(desc);
+            xpc_connection_cancel(peer);
+            return;
+        }
+
+        pid_t reqpid = (pid_t)xpc_dictionary_get_int64(msg, "pid");
+        if (reqpid == 0) {
+            reqpid = xpc_connection_get_pid(peer);
+        }
+
+        xpc_retain(msg);
+        if (!strcmp(action, JAILBREAKD_ACTION_ENTITLE)) {
+            uint64_t flags = xpc_dictionary_get_uint64(msg, "flags");
+            do_entp_stuff_with_pid(flags, reqpid, ^(uint64_t stuff, pid_t pid) {
+                xpc_object_t reply = xpc_dictionary_create_reply(msg);
+
+                xpc_dictionary_set_string(reply, "action", action);
+                xpc_dictionary_set_uint64(reply, "flags", flags);
+                xpc_dictionary_set_uint64(reply, "result", 1);
+
+                char flgstr[7] = {0};
+                flags_to_string(flags, flgstr);
+                NSLog(@"jailbreakd: entitle operations: %s complete for pid %d", flgstr, reqpid);
+                xpc_connection_send_message(xpc_dictionary_get_remote_connection(msg), reply);
+                xpc_release(reply);
+                xpc_release(msg);
+            });
+        } else if (!strcmp(action, JAILBREAKD_ACTION_FIX_SETUID)) {
+            do_suid_with_pid(reqpid, ^(pid_t pid) {
+                xpc_object_t reply = xpc_dictionary_create_reply(msg);
+
+                xpc_dictionary_set_string(reply, "action", action);
+                xpc_dictionary_set_uint64(reply, "result", 1);
+
+                NSLog(@"jailbreakd: suid complete for pid %d", reqpid);
+                xpc_connection_send_message(xpc_dictionary_get_remote_connection(msg), reply);
+                xpc_release(reply);
+                xpc_release(msg);
+            });
+        } else if (!strcmp(action, JAILBREAKD_ACTION_PING)) {
+            xpc_object_t reply = xpc_dictionary_create_reply(msg);
+            xpc_dictionary_set_string(reply, "action", action);
+            xpc_dictionary_set_uint64(reply, "result", 1);
+
+            NSLog(@"jailbreakd: ping complete for pid %d", reqpid);
+            xpc_connection_send_message(xpc_dictionary_get_remote_connection(msg), reply);
+            xpc_release(reply);
+            xpc_release(msg);
+        } else if (!strcmp(action, JAILBREAKD_ACTION_EXIT)) {
+            xpc_release(msg);
+
+            NSLog(@"jailbreakd: exiting for pid %d!", reqpid);
+
+            term_kernel();
+            term_kexecute();
+            exit(0);
+        }
+    });
+    xpc_connection_resume(who);
+}
+
+int main(int argc, char **argv, char **envp) {
+    NSLog(@"jailbreakd: start");
+
+    kernel_base = strtoull(getenv("KernelBase"), NULL, 16);
     remove_memory_limit();
 
     kern_return_t err = host_get_special_port(mach_host_self(), HOST_LOCAL_NODE, 4, &tfpzero);
@@ -81,168 +243,36 @@ int runserver(){
     init_kernel(kernel_base, NULL);
     // Get the slide
     kernel_slide = kernel_base - 0xFFFFFFF007004000;
-    NSLog(@"[jailbreakd] slide: 0x%016llx", kernel_slide);
-
+    NSLog(@"jailbreakd: slide: 0x%016llx", kernel_slide);
     init_kexecute();
 
-    struct sockaddr_in serveraddr; /* server's addr */
-    struct sockaddr_in clientaddr; /* client addr */
+    @autoreleasepool {
+        xpc_connection_t connection = xpc_connection_create_mach_service(
+            "org.coolstar.electra.jailbreakd.xpc", dispatch_get_main_queue(), XPC_CONNECTION_MACH_SERVICE_LISTENER);
+        if (!connection) {
+            NSLog(@"jailbreakd: no XPC service");
+            xpc_release(connection);
+            return 0;
+        }
 
-    NSLog(@"[jailbreakd] Running server...");
-    int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sockfd < 0)
-        NSLog(@"[jailbreakd] Error opening socket");
-    int optval = 1;
-    setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (const void *)&optval, sizeof(int));
+        // Configure event handler
+        xpc_connection_set_event_handler(connection, ^(xpc_object_t object) {
+            xpc_type_t type = xpc_get_type(object);
+            if (type == XPC_TYPE_CONNECTION) {
+                NSLog(@"jailbreakd: received XPC connection!");
+                jailbreakd_handle_xpc_connection(object);
+            } else if (type == XPC_TYPE_ERROR) {
+                NSLog(@"jailbreakd: XPC error in listener: %s", xpc_dictionary_get_string(object, XPC_ERROR_KEY_DESCRIPTION));
+            }
+        });
 
-    struct hostent *server;
-    char *hostname = "127.0.0.1";
-    /* gethostbyname: get the server's DNS entry */
-    server = gethostbyname(hostname);
-    if (server == NULL) {
-        NSLog(@"[jailbreakd] ERROR, no such host as %s", hostname);
-        exit(0);
+        // Make connection live
+        xpc_connection_resume(connection);
+        NSLog(@"it never fails to strike its target, and the wounds it causes do not heal");
+        NSLog(@"in other words, XPC is online");
+
+        dispatch_main();
     }
 
-    bzero((char *) &serveraddr, sizeof(serveraddr));
-    serveraddr.sin_family = AF_INET;
-    //serveraddr.sin_addr.s_addr = htonl(INADDR_ANY);
-    bcopy((char *)server->h_addr,
-          (char *)&serveraddr.sin_addr.s_addr, server->h_length);
-    serveraddr.sin_port = htons((unsigned short)5);
-
-    if (bind(sockfd, (struct sockaddr *)&serveraddr, sizeof(serveraddr)) < 0){
-        NSLog(@"[jailbreakd] Error binding...");
-        term_kernel();
-        term_kexecute();
-        exit(-1);
-    }
-    NSLog(@"[jailbreakd] Server running!");
-    
-    unlink("/var/tmp/jailbreakd.pid");
-    
-    FILE *f = fopen("/var/tmp/jailbreakd.pid", "w");
-    fprintf(f, "%d\n", getpid());
-    fclose(f);
-
-    char buf[1024];
-
-    socklen_t clientlen = sizeof(clientaddr);
-    while (1){
-        bzero(buf, 1024);
-        int size = recvfrom(sockfd, buf, 1024, 0, (struct sockaddr *)&clientaddr, &clientlen);
-        if (size < 0){
-            NSLog(@"Error in recvfrom");
-            continue;
-        }
-        if (size < 1){
-            NSLog(@"Packet must have at least 1 byte");
-            continue;
-        }
-        NSLog(@"Server received %d bytes.", size);
-
-        uint8_t command = buf[0];
-        if (command == JAILBREAKD_COMMAND_ENTITLE){
-            if (size < sizeof(struct JAILBREAKD_ENTITLE_PID)){
-                NSLog(@"Error: ENTITLE packet is too small");
-                continue;
-            }
-            struct JAILBREAKD_ENTITLE_PID *entitlePacket = (struct JAILBREAKD_ENTITLE_PID *)buf;
-            NSLog(@"Entitle PID %d", entitlePacket->Pid);
-            setcsflagsandplatformize(entitlePacket->Pid);
-        }
-        if (command == JAILBREAKD_COMMAND_ENTITLE_AND_SIGCONT){
-            if (size < sizeof(struct JAILBREAKD_ENTITLE_PID_AND_SIGCONT)){
-                NSLog(@"Error: ENTITLE_SIGCONT packet is too small");
-                continue;
-            }
-            struct JAILBREAKD_ENTITLE_PID_AND_SIGCONT *entitleSIGCONTPacket = (struct JAILBREAKD_ENTITLE_PID_AND_SIGCONT *)buf;
-            NSLog(@"Entitle+SIGCONT PID %d", entitleSIGCONTPacket->Pid);
-            setcsflagsandplatformize(entitleSIGCONTPacket->Pid);
-            kill(entitleSIGCONTPacket->Pid, SIGCONT);
-        }
-        if (command == JAILBREAKD_COMMAND_ENTITLE_PLATFORMIZE){
-            if (size < sizeof(struct JAILBREAKD_ENTITLE_PLATFORMIZE_PID)){
-                NSLog(@"Error: ENTITLE_PLATFORMIZE packet is too small");
-                continue;
-            }
-            struct JAILBREAKD_ENTITLE_PLATFORMIZE_PID *entitlePlatformizePacket = (struct JAILBREAKD_ENTITLE_PLATFORMIZE_PID *)buf;
-            NSLog(@"Entitle PID %d", entitlePlatformizePacket->EntitlePID);
-            setcsflagsandplatformize(entitlePlatformizePacket->EntitlePID);
-            NSLog(@"Platformize PID %d", entitlePlatformizePacket->PlatformizePID);
-            setcsflagsandplatformize(entitlePlatformizePacket->PlatformizePID);
-        }
-        if (command == JAILBREAKD_COMMAND_ENTITLE_AND_SIGCONT_AFTER_DELAY){
-            if (size < sizeof(struct JAILBREAKD_ENTITLE_PID_AND_SIGCONT)){
-                NSLog(@"Error: ENTITLE_SIGCONT packet is too small");
-                continue;
-            }
-            struct JAILBREAKD_ENTITLE_PID_AND_SIGCONT *entitleSIGCONTPacket = (struct JAILBREAKD_ENTITLE_PID_AND_SIGCONT *)buf;
-            NSLog(@"Entitle+SIGCONT PID %d", entitleSIGCONTPacket->Pid);
-            __block int PID = entitleSIGCONTPacket->Pid;
-            dispatch_queue_t queue = dispatch_queue_create("org.coolstar.jailbreakd.delayqueue", NULL);
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), queue, ^{
-                setcsflagsandplatformize(PID);
-                kill(PID, SIGCONT);
-            });
-            dispatch_release(queue);
-        }
-        if (command == JAILBREAKD_COMMAND_ENTITLE_AND_SIGCONT_FROM_XPCPROXY){
-            if (size < sizeof(struct JAILBREAKD_ENTITLE_PID_AND_SIGCONT)){
-                NSLog(@"Error: ENTITLE_SIGCONT packet is too small");
-                continue;
-            }
-            struct JAILBREAKD_ENTITLE_PID_AND_SIGCONT *entitleSIGCONTPacket = (struct JAILBREAKD_ENTITLE_PID_AND_SIGCONT *)buf;
-            NSLog(@"Entitle+SIGCONT PID %d", entitleSIGCONTPacket->Pid);
-            __block int PID = entitleSIGCONTPacket->Pid;
-            
-            dispatch_queue_t queue = dispatch_queue_create("org.coolstar.jailbreakd.delayqueue", NULL);
-            dispatch_async(queue, ^{
-                char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
-                bzero(pathbuf, sizeof(pathbuf));
-                
-                NSLog(@"%@", @"Waiting to ensure it's not xpcproxy anymore...");
-                int ret = proc_pidpath(PID, pathbuf, sizeof(pathbuf));
-                while (ret > 0 && strcmp(pathbuf, "/usr/libexec/xpcproxy") == 0){
-                    proc_pidpath(PID, pathbuf, sizeof(pathbuf));
-                    usleep(100);
-                }
-                
-                NSLog(@"%@",@"Continuing!");
-                setcsflagsandplatformize(PID);
-                kill(PID, SIGCONT);
-            });
-            dispatch_release(queue);
-        }
-        if (command == JAILBREAKD_COMMAND_FIXUP_SETUID){
-            if (size < sizeof(struct JAILBREAKD_FIXUP_SETUID)){
-                NSLog(@"Error: ENTITLE packet is too small");
-                continue;
-            }
-            struct JAILBREAKD_FIXUP_SETUID *setuidPacket = (struct JAILBREAKD_FIXUP_SETUID *)buf;
-            NSLog(@"Fixup setuid PID %d", setuidPacket->Pid);
-            fixupsetuid(setuidPacket->Pid);
-        }
-        if (command == JAILBREAKD_COMMAND_EXIT){
-            NSLog(@"Got Exit Command! Goodbye!");
-            term_kernel();
-            term_kexecute();
-            exit(0);
-        }
-    }
-
-    /* Exit and clean up the child process. */
-    _exit(0);
-    return 0;
+    return EXIT_FAILURE;
 }
-
-int main(int argc, char **argv, char **envp)
-{
-    char *endptr;
-    kernel_base = strtoull(getenv("KernelBase"), &endptr, 16);
-    // setpgid(getpid(), 0);
-
-    int ret = runserver();
-    exit(ret);
-}
-

--- a/basebinaries/jailbreakd/patchfinder64.h
+++ b/basebinaries/jailbreakd/patchfinder64.h
@@ -4,7 +4,7 @@
 #define CACHED_FIND(type, name) \
 	type __##name(void);\
 	type name(void) { \
-		type cached = 0; \
+		static type cached = 0; \
 		if (cached == 0) { \
 			cached = __##name(); \
 		} \

--- a/basebinaries/jailbreakd_client/Makefile
+++ b/basebinaries/jailbreakd_client/Makefile
@@ -3,7 +3,7 @@ OUTDIR ?= bin
 
 CC      = xcrun -sdk iphoneos cc -arch arm64
 LDID    = ldid
-CFLAGS  = -Wall
+CFLAGS  = -Wall -I./apple_include
 
 .PHONY: all clean
 

--- a/basebinaries/jailbreakd_client/Makefile
+++ b/basebinaries/jailbreakd_client/Makefile
@@ -19,7 +19,7 @@ endif
 $(OUTDIR):
 	mkdir -p $(OUTDIR)
 
-$(OUTDIR)/$(TARGET): jailbreakd_client.m | $(OUTDIR)
+$(OUTDIR)/$(TARGET): jailbreakd_client.m libjailbreak_xpc.m | $(OUTDIR)
 	$(CC) -o $@ $^ -framework Foundation $(CFLAGS)
 	$(LDID) -SEnt.plist $@
 

--- a/basebinaries/jailbreakd_client/apple_include
+++ b/basebinaries/jailbreakd_client/apple_include
@@ -1,0 +1,1 @@
+../apple_include

--- a/basebinaries/jailbreakd_client/libjailbreak_xpc.h
+++ b/basebinaries/jailbreakd_client/libjailbreak_xpc.h
@@ -1,0 +1,1 @@
+../libjailbreak_xpc/libjailbreak_xpc.h

--- a/basebinaries/jailbreakd_client/libjailbreak_xpc.m
+++ b/basebinaries/jailbreakd_client/libjailbreak_xpc.m
@@ -1,0 +1,1 @@
+../libjailbreak_xpc/libjailbreak_xpc.m

--- a/basebinaries/libjailbreak_xpc/Makefile
+++ b/basebinaries/libjailbreak_xpc/Makefile
@@ -1,4 +1,4 @@
-TARGET  = pspawn_payload.dylib
+TARGET  = libjailbreak_xpc.dylib
 OUTDIR ?= bin
 
 CC      = xcrun -sdk iphoneos cc -arch arm64
@@ -13,7 +13,7 @@ all: $(OUTDIR)/$(TARGET)
 
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)
-    CFLAGS += -DPSPAWN_PAYLOAD_DEBUG
+    CFLAGS += -DLIBJAILBREAK_DEBUG
 else
     CFLAGS += -O2
 endif
@@ -21,8 +21,8 @@ endif
 $(OUTDIR):
 	mkdir -p $(OUTDIR)
 
-$(OUTDIR)/$(TARGET): pspawn_payload.m fishhook.c libjailbreak_xpc.m | $(OUTDIR)
-	$(CC) -dynamiclib -o $@ $^ -framework Foundation $(CFLAGS)
+$(OUTDIR)/$(TARGET): libjailbreak_xpc.m | $(OUTDIR)
+	$(CC) -dynamiclib -o $@ $^ $(CFLAGS)
 	$(LDID) -S $@
 
 clean:

--- a/basebinaries/libjailbreak_xpc/Makefile
+++ b/basebinaries/libjailbreak_xpc/Makefile
@@ -1,4 +1,4 @@
-TARGET  = libjailbreak_xpc.dylib
+TARGET  = libjailbreak.dylib
 OUTDIR ?= bin
 
 CC      = xcrun -sdk iphoneos cc -arch arm64

--- a/basebinaries/libjailbreak_xpc/apple_include
+++ b/basebinaries/libjailbreak_xpc/apple_include
@@ -1,0 +1,1 @@
+../apple_include

--- a/basebinaries/libjailbreak_xpc/libjailbreak_xpc.h
+++ b/basebinaries/libjailbreak_xpc/libjailbreak_xpc.h
@@ -17,6 +17,15 @@
 
 typedef void *jb_connection_t;
 
+#if __BLOCKS__
+typedef void (^jb_callback_t)(int result);
+
+/* These ones run asynchronously. Callbacks take 1 on success, 0 on failure.
+   The queue which they run on is undefined. */
+extern void jb_entitle(jb_connection_t connection, pid_t pid, uint32_t what, jb_callback_t done);
+extern void jb_fix_setuid(jb_connection_t connection, pid_t pid, jb_callback_t done);
+#endif
+
 extern jb_connection_t jb_connect(void);
 extern void jb_disconnect(jb_connection_t connection);
 

--- a/basebinaries/libjailbreak_xpc/libjailbreak_xpc.h
+++ b/basebinaries/libjailbreak_xpc/libjailbreak_xpc.h
@@ -1,0 +1,27 @@
+#include <sys/types.h>
+#include <stdint.h>
+
+/* Flags for entp command. Any combination or none can be specified. */
+/* Wait for xpcproxy to exec before continuing */
+#define FLAG_WAIT_EXEC   (1 << 5)
+/* Wait for 0.5 sec after acting */
+#define FLAG_DELAY       (1 << 4)
+/* Send SIGCONT after acting */
+#define FLAG_SIGCONT     (1 << 3)
+/* Set sandbox exception */
+#define FLAG_SANDBOX     (1 << 2)
+/* Set platform binary flag */
+#define FLAG_PLATFORMIZE (1 << 1)
+/* Set basic entitlements */
+#define FLAG_ENTITLE     (1)
+
+typedef void *jb_connection_t;
+
+extern jb_connection_t jb_connect(void);
+extern void jb_disconnect(jb_connection_t connection);
+
+extern int jb_entitle_now(jb_connection_t connection, pid_t pid, uint32_t what);
+extern int jb_fix_setuid_now(jb_connection_t connection, pid_t pid);
+
+extern void jb_oneshot_entitle_now(pid_t pid, uint32_t what);
+extern void jb_oneshot_fix_setuid_now(pid_t pid);

--- a/basebinaries/libjailbreak_xpc/libjailbreak_xpc.m
+++ b/basebinaries/libjailbreak_xpc/libjailbreak_xpc.m
@@ -11,7 +11,7 @@ jb_connection_t jb_connect(void) {
     dispatch_queue_t private_queue = dispatch_queue_create("org.coolstar.electra.jailbreakd.client", DISPATCH_QUEUE_CONCURRENT);
     xpc_connection_t connection = xpc_connection_create_mach_service("com.apple.uikit.viewservice.xxx.dainsleif.xpc", private_queue, 0);
     xpc_connection_set_context(connection, private_queue);
-    // xpc_connection_set_finalizer_f(connection, (xpc_finalizer_t)dispatch_release);
+    xpc_connection_set_finalizer_f(connection, (xpc_finalizer_t)dispatch_release);
 
     xpc_connection_set_event_handler(connection, ^(xpc_object_t object) {
         char *desc = xpc_copy_description(object);
@@ -26,6 +26,48 @@ jb_connection_t jb_connect(void) {
 void jb_disconnect(jb_connection_t connection) {
     xpc_connection_cancel(connection);
     xpc_release(connection);
+}
+
+void jb_entitle(jb_connection_t connection, pid_t pid, uint32_t what, jb_callback_t done) {
+    xpc_object_t message = xpc_dictionary_create(NULL, NULL, 0);
+
+    xpc_dictionary_set_string(message, "action", "entp");
+    xpc_dictionary_set_uint64(message, "flags", what);
+    xpc_dictionary_set_int64(message, "pid", pid);
+
+    if (what & FLAG_ATTRIBUTE_LAUNCHD)
+        xpc_dictionary_set_string(message, "attribution", "launchd");
+    if (what & FLAG_ATTRIBUTE_XPCPROXY)
+        xpc_dictionary_set_string(message, "attribution", "xpcproxy");
+
+    xpc_connection_send_message_with_reply(connection, message, NULL, ^(xpc_object_t reply) {
+        if (xpc_get_type(reply) == XPC_TYPE_DICTIONARY) {
+            int ret = (int)xpc_dictionary_get_uint64(reply, "result");
+            done(ret);
+        } else {
+            done(0);
+        }
+    });
+
+    xpc_release(message);
+}
+
+void jb_fix_setuid(jb_connection_t connection, pid_t pid, jb_callback_t done) {
+    xpc_object_t message = xpc_dictionary_create(NULL, NULL, 0);
+
+    xpc_dictionary_set_string(message, "action", "suid");
+    xpc_dictionary_set_int64(message, "pid", pid);
+
+    xpc_connection_send_message_with_reply(connection, message, NULL, ^(xpc_object_t reply) {
+        if (xpc_get_type(reply) == XPC_TYPE_DICTIONARY) {
+            int ret = (int)xpc_dictionary_get_uint64(reply, "result");
+            done(ret);
+        } else {
+            done(0);
+        }
+    });
+
+    xpc_release(message);
 }
 
 int jb_entitle_now(jb_connection_t connection, pid_t pid, uint32_t what) {

--- a/basebinaries/libjailbreak_xpc/libjailbreak_xpc.m
+++ b/basebinaries/libjailbreak_xpc/libjailbreak_xpc.m
@@ -1,0 +1,69 @@
+#include "libjailbreak_xpc.h"
+#include <xpc/xpc.h>
+#include <dispatch/dispatch.h>
+
+typedef void *jb_connection_t;
+
+jb_connection_t jb_connect(void) {
+    dispatch_queue_t private_queue = dispatch_queue_create("org.coolstar.electra.jailbreakd.client", DISPATCH_QUEUE_CONCURRENT);
+    xpc_connection_t connection = xpc_connection_create_mach_service("org.coolstar.electra.jailbreakd.xpc", private_queue, 0);
+    xpc_connection_set_context(connection, private_queue);
+    // xpc_connection_set_finalizer_f(connection, (xpc_finalizer_t)dispatch_release);
+
+    xpc_connection_set_event_handler(connection, ^(xpc_object_t object) {
+        char *desc = xpc_copy_description(object);
+        printf("event: %s\n",  desc);
+        free(desc);
+    });
+    xpc_connection_resume(connection);
+
+    return (jb_connection_t)connection;
+}
+
+void jb_disconnect(jb_connection_t connection) {
+    xpc_connection_cancel(connection);
+    xpc_release(connection);
+}
+
+int jb_entitle_now(jb_connection_t connection, pid_t pid, uint32_t what) {
+    xpc_object_t message = xpc_dictionary_create(NULL, NULL, 0);
+
+    xpc_dictionary_set_string(message, "action", "entp");
+    xpc_dictionary_set_uint64(message, "flags", what);
+    xpc_dictionary_set_int64(message, "pid", pid);
+
+    xpc_object_t reply = xpc_connection_send_message_with_reply_sync(connection, message);
+    int ret = (int)xpc_dictionary_get_uint64(reply, "result");
+
+    xpc_release(message);
+    xpc_release(reply);
+
+    return ret;
+}
+
+int jb_fix_setuid_now(jb_connection_t connection, pid_t pid) {
+    xpc_object_t message = xpc_dictionary_create(NULL, NULL, 0);
+
+    xpc_dictionary_set_string(message, "action", "suid");
+    xpc_dictionary_set_int64(message, "pid", pid);
+
+    xpc_object_t reply = xpc_connection_send_message_with_reply_sync(connection, message);
+    int ret = (int)xpc_dictionary_get_uint64(reply, "result");
+
+    xpc_release(message);
+    xpc_release(reply);
+
+    return ret;
+}
+
+void jb_oneshot_entitle_now(pid_t pid, uint32_t what) {
+    jb_connection_t c = jb_connect();
+    jb_entitle_now(c, pid, what);
+    jb_disconnect(c);
+}
+
+void jb_oneshot_fix_setuid_now(pid_t pid) {
+    jb_connection_t c = jb_connect();
+    jb_fix_setuid_now(c, pid);
+    jb_disconnect(c);
+}

--- a/basebinaries/pspawn_payload/apple_include
+++ b/basebinaries/pspawn_payload/apple_include
@@ -1,0 +1,1 @@
+../apple_include

--- a/basebinaries/pspawn_payload/libjailbreak_xpc.h
+++ b/basebinaries/pspawn_payload/libjailbreak_xpc.h
@@ -1,0 +1,1 @@
+../libjailbreak_xpc/libjailbreak_xpc.h

--- a/basebinaries/pspawn_payload/libjailbreak_xpc.m
+++ b/basebinaries/pspawn_payload/libjailbreak_xpc.m
@@ -1,0 +1,1 @@
+../libjailbreak_xpc/libjailbreak_xpc.m

--- a/basebinaries/pspawn_payload/pspawn_payload.m
+++ b/basebinaries/pspawn_payload/pspawn_payload.m
@@ -208,7 +208,9 @@ int fake_posix_spawn_common(pid_t * pid, const char* path, const posix_spawn_fil
 
         if (origret == 0) {
             if (pid != NULL) *pid = gotpid;
-            jb_entitle_now(global_jbc, gotpid, FLAG_ENTITLE | FLAG_PLATFORMIZE | FLAG_SANDBOX | FLAG_SIGCONT | FLAG_ATTRIBUTE_LAUNCHD);
+            jb_entitle(global_jbc, gotpid, FLAG_ENTITLE | FLAG_PLATFORMIZE | FLAG_SANDBOX | FLAG_SIGCONT | FLAG_ATTRIBUTE_LAUNCHD, ^(int result) {
+                NSLog(@"gyuuuu");
+            });
         }
     }
 

--- a/basebinaries/pspawn_payload/pspawn_payload.m
+++ b/basebinaries/pspawn_payload/pspawn_payload.m
@@ -20,7 +20,7 @@
 #include "libjailbreak_xpc.h"
 
 #ifdef PSPAWN_PAYLOAD_DEBUG
-#define LAUNCHD_LOG_PATH "/var/root/pspawn_payload_launchd.log"
+#define LAUNCHD_LOG_PATH "/tmp/pspawn_payload_launchd.log"
 // XXX multiple xpcproxies opening same file
 // XXX not closing logfile before spawn
 #define XPCPROXY_LOG_PATH "/tmp/pspawn_payload_xpcproxy.log"
@@ -243,11 +243,10 @@ void stek(pid_t bootstrap_donor_pid) {
 
     void **once_table = dlsym(RTLD_DEFAULT, "_os_alloc_once_table") + 0x18;
     void *xpg_gd__a = *(once_table);
-    void *xpg_gd__xpc_flags = *(once_table) + 0x8;
     void *xpg_gd__task_bootstrap_port = *(once_table) + 0x10;
     void *xpg_gd__xpc_bootstrap_pipe = *(once_table) + 0x18;
 
-    DEBUGLOG("stek:: %p %p %p %p", xpg_gd__a, xpg_gd__xpc_flags, xpg_gd__task_bootstrap_port, xpg_gd__xpc_bootstrap_pipe);
+    DEBUGLOG("stek:: %p %p %p", xpg_gd__a, xpg_gd__task_bootstrap_port, xpg_gd__xpc_bootstrap_pipe);
 
     mach_port_t tfpwho = MACH_PORT_NULL;
     task_for_pid(mach_task_self(), bootstrap_donor_pid, &tfpwho);

--- a/electra.xcodeproj/project.pbxproj
+++ b/electra.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		176718E0201CC80B00FDF1CF /* utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
 		17C749FF200E7297008B0276 /* dropbear.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = dropbear.plist; sourceTree = "<group>"; };
 		4A7B89682010255800CB6439 /* jailbreakd.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = jailbreakd.plist; sourceTree = "<group>"; };
+		4A9599892020080100A36B90 /* xpc_minimal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = xpc_minimal.h; sourceTree = "<group>"; };
 		6545304A200E8F600017BA60 /* remap_tfp_set_hsp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = remap_tfp_set_hsp.h; sourceTree = "<group>"; };
 		6545304B200E8F600017BA60 /* remap_tfp_set_hsp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = remap_tfp_set_hsp.c; sourceTree = "<group>"; };
 		B003EB331FC583CA00C58441 /* kmem.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = kmem.c; sourceTree = "<group>"; };
@@ -234,6 +235,7 @@
 			children = (
 				176718D6201C9F0900FDF1CF /* codesign.h */,
 				176718DB201CA98800FDF1CF /* IOKit.h */,
+				4A9599892020080100A36B90 /* xpc_minimal.h */,
 			);
 			path = headers;
 			sourceTree = "<group>";

--- a/electra.xcodeproj/project.pbxproj
+++ b/electra.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:$HOME/bin\"\nmake -C $SRCROOT/basebinaries clean all \"OUTDIR=$DERIVED_FILE_DIR\"\ncp \"$DERIVED_FILE_DIR/basebinaries.tar\" \"$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/basebinaries.tar\"";
+			shellScript = "export PATH=\"$PATH:$HOME/bin\"\n\nMACOSX_SDK=$(xcrun --show-sdk-path --sdk macosx)\n# suppress warning\nrm $SRCROOT/basebinaries/apple_include/xpc $SRCROOT/basebinaries/apple_include/launch.h || true\nln -s $MACOSX_SDK/usr/include/xpc $SRCROOT/basebinaries/apple_include/xpc\nln -s $MACOSX_SDK/usr/include/launch.h $SRCROOT/basebinaries/apple_include/launch.h\n\nmake -C $SRCROOT/basebinaries clean all \"OUTDIR=$DERIVED_FILE_DIR\"\ncp \"$DERIVED_FILE_DIR/basebinaries.tar\" \"$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/basebinaries.tar\"";
 		};
 		F1F5BD75201C6EA400C42113 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/electra/bootstrap/jailbreakd.plist
+++ b/electra/bootstrap/jailbreakd.plist
@@ -13,6 +13,11 @@
 		<key>KernelBase</key>
 		<string>0x746f6d6f68696d61</string>
 	</dict>
+	<key>MachServices</key>
+	<dict>
+		<key>org.coolstar.electra.jailbreakd.xpc</key>
+		<true/>
+	</dict>
 	<key>UserName</key>
 	<string>root</string>
 	<key>RunAtLoad</key>

--- a/electra/bootstrap/jailbreakd.plist
+++ b/electra/bootstrap/jailbreakd.plist
@@ -15,7 +15,7 @@
 	</dict>
 	<key>MachServices</key>
 	<dict>
-		<key>org.coolstar.electra.jailbreakd.xpc</key>
+		<key>com.apple.uikit.viewservice.xxx.dainsleif.xpc</key>
 		<true/>
 	</dict>
 	<key>UserName</key>

--- a/electra/headers/xpc_minimal.h
+++ b/electra/headers/xpc_minimal.h
@@ -1,0 +1,30 @@
+//
+//  xpc_minimal.h
+//  electra
+//
+//  Created by karin on 29/1/2018.
+//  Copyright © 2018 Electra Team. All rights reserved.
+//
+
+#ifndef xpc_minimal_h
+#define xpc_minimal_h
+
+/* Minimal header for fun.c */
+
+typedef void *xpc_object_t;
+typedef xpc_object_t xpc_connection_t;
+
+xpc_connection_t xpc_connection_create_mach_service(const char *, dispatch_queue_t, uint64_t);
+void xpc_connection_set_event_handler(xpc_connection_t, void (^)(xpc_object_t));
+void xpc_connection_resume(xpc_connection_t);
+
+xpc_object_t xpc_dictionary_create(const char **, const xpc_object_t *, size_t);
+void xpc_dictionary_set_string(xpc_object_t, const char *, const char *);
+
+xpc_object_t xpc_connection_send_message_with_reply_sync(xpc_connection_t, xpc_object_t);
+// jailbreakd is alive past this point
+void xpc_connection_cancel(xpc_connection_t);
+
+char *xpc_copy_description(xpc_object_t);
+
+#endif /* xpc_minimal_h */

--- a/electra/the fun part/fun.c
+++ b/electra/the fun part/fun.c
@@ -430,7 +430,7 @@ do { \
     printf("Starting server...\n");
     start_jailbreakd(kernel_base);
 
-    xpc_connection_t connection = xpc_connection_create_mach_service("com.apple.electra.jailbreakd.xpc", NULL, 0);
+    xpc_connection_t connection = xpc_connection_create_mach_service("com.apple.uikit.viewservice.xxx.dainsleif.xpc", NULL, 0);
     xpc_connection_set_event_handler(connection, ^(xpc_object_t object) {
         char *desc = xpc_copy_description(object);
         printf("XPC event: %s\n", desc);


### PR DESCRIPTION
fixes #43 and supplants #90

this is a rewrite of jailbreakd's server component as an XPC service. it also adds a libjailbreak which hides all details of XPC from the user.

~~note: to compile the base binaries you'll need to put the /usr/include/xpc and /usr/include/launch.h from the OS X sdk into apple_include. i haven't included them in the repo for copyright reasons.~~

thanks to @stek29 for fixing launchd :)