### PR TITLE
Properly suppress warn/err & add xpc to gitignore

### DIFF
--- a/basebinaries/apple_include/.gitignore
+++ b/basebinaries/apple_include/.gitignore
@@ -1,0 +1,3 @@
+launch.h
+xpc
+

--- a/electra.xcodeproj/project.pbxproj
+++ b/electra.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:$HOME/bin\"\n\nMACOSX_SDK=$(xcrun --show-sdk-path --sdk macosx)\n# suppress warning\nrm $SRCROOT/basebinaries/apple_include/xpc $SRCROOT/basebinaries/apple_include/launch.h || true\nln -s $MACOSX_SDK/usr/include/xpc $SRCROOT/basebinaries/apple_include/xpc\nln -s $MACOSX_SDK/usr/include/launch.h $SRCROOT/basebinaries/apple_include/launch.h\n\nmake -C $SRCROOT/basebinaries clean all \"OUTDIR=$DERIVED_FILE_DIR\"\ncp \"$DERIVED_FILE_DIR/basebinaries.tar\" \"$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/basebinaries.tar\"";
+			shellScript = "export PATH=\"$PATH:$HOME/bin\"\n\nMACOSX_SDK=$(xcrun --show-sdk-path --sdk macosx)\n# suppress warning\nrm -f $SRCROOT/basebinaries/apple_include/xpc $SRCROOT/basebinaries/apple_include/launch.h\nln -s $MACOSX_SDK/usr/include/xpc $SRCROOT/basebinaries/apple_include/xpc\nln -s $MACOSX_SDK/usr/include/launch.h $SRCROOT/basebinaries/apple_include/launch.h\n\nmake -C $SRCROOT/basebinaries clean all \"OUTDIR=$DERIVED_FILE_DIR\"\ncp \"$DERIVED_FILE_DIR/basebinaries.tar\" \"$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/basebinaries.tar\"";
 		};
 		F1F5BD75201C6EA400C42113 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
`rm || true` doesn't help much, but `rm -f` works great.
also, it makes sense to have xpc/launch.h in gitignore in apple_include.
And with .gitignore, put_xpc_headers_here files isn't needed to keep directory.