### PR TITLE
Fix iPhone X safe mode unlock gesture

### DIFF
--- a/sbinject/SBInject.x
+++ b/sbinject/SBInject.x
@@ -111,15 +111,14 @@ int file_exist(char *filename) {
 @end
 
 %group SafeMode
-%hook SBLockScreenViewController
--(void)finishUIUnlockFromSource:(int)source {
+%hook SBLockScreenManager
+-(BOOL)_finishUIUnlockFromSource:(int)arg1 withOptions:(id)arg2 {
     %orig;
     [(SpringBoard *)[%c(UIApplication) sharedApplication] launchApplicationWithIdentifier:@"org.coolstar.SafeMode" suspended:NO];
 }
-%end
 
-%hook SBDashBoardViewController
--(void)finishUIUnlockFromSource:(int)source {
+// Necessary on iPhone X to show during after swipe unlock gesture
+-(void)lockScreenViewControllerDidDismiss {
     %orig;
     [(SpringBoard *)[%c(UIApplication) sharedApplication] launchApplicationWithIdentifier:@"org.coolstar.SafeMode" suspended:NO];
 }

--- a/sbinject/SBInject.x
+++ b/sbinject/SBInject.x
@@ -117,7 +117,7 @@ int file_exist(char *filename) {
     [(SpringBoard *)[%c(UIApplication) sharedApplication] launchApplicationWithIdentifier:@"org.coolstar.SafeMode" suspended:NO];
 }
 
-// Necessary on iPhone X to show during after swipe unlock gesture
+// Necessary on iPhone X to show after swipe unlock gesture
 -(void)lockScreenViewControllerDidDismiss {
     %orig;
     [(SpringBoard *)[%c(UIApplication) sharedApplication] launchApplicationWithIdentifier:@"org.coolstar.SafeMode" suspended:NO];


### PR DESCRIPTION
When iPhone X is unlocked with Face ID, it allows you to swipe up the Lock Screen interactively. When Electra is in safe mode on the iPhone X, this gesture doesn't work. As you swipe, the Lock Screen is frustratingly pulled back down, requiring you to lock your phone again, swipe up with it pointed away from your face, and then bring your face into view.

This pull request changes where SBInject's safe mode hooks in order to work properly with this gesture, as well as all other devices.